### PR TITLE
Add gunicorn to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ celery==4.3.0
 Click==7.0
 Flask==1.0.2
 flower==0.9.3
+gunicorn==19.9.0
 itsdangerous==1.1.0
 Jinja2==2.10.1
 kombu==4.5.0


### PR DESCRIPTION
Noticed gunicorn was missing from the dependency list after trying to follow the celery instructions in the docs