### PR TITLE
Fix build issue resulting from Kombu

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,7 @@ Flask==1.0.2
 flower==0.9.3
 gunicorn==19.9.0
 redis==3.2.1
+
+# NOTE: Kombu 4.6.5 results in a build failure. Bumping down to 4.6.4
+#       See this github issue: https://github.com/celery/kombu/issues/1063
+kombu==4.6.4


### PR DESCRIPTION
When deploying a new Celery worker, I was encountering this error during the build step:
```bash
Control command error: OperationalError("\nCannot route message for exchange 'reply.celery.pidbox': Table empty or key no longer exists.\nProbably the key ('_kombu.binding.reply.celery.pidbox') has been removed from the Redis database.\n")
```

I found this [open GitHub issue](https://github.com/celery/kombu/issues/1063) where others had encountered the same problem.

The issue seemed to arise when `kombu` moved from version `4.6.4` to `4.6.5`. Folks in the comments seemed to have success bumping the `kombu` version down to `4.6.4`, which worked for me.

### Worth Noting
Some folks in the comments on this issue noted that `4.6.4` did not work for them, but `4.6.3` did.

In this PR, I went with `4.6.4` because that worked for me on Render.

I haven't modified anything else about this Celery template.
