### PR TITLE
Sets autoDeploy to false

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -5,6 +5,7 @@ services:
     env: python
     buildCommand: "pip install -r requirements.txt"
     startCommand: "celery --app tasks worker --loglevel info --concurrency 4"
+    autoDeploy: false
     envVars:
       - key: CELERY_BROKER_URL
         fromService:
@@ -17,6 +18,7 @@ services:
     env: python
     buildCommand: "pip install -r requirements.txt"
     startCommand: "gunicorn app:app"
+    autoDeploy: false
     envVars:
       - key: CELERY_BROKER_URL
         fromService:
@@ -30,6 +32,7 @@ services:
     env: python
     buildCommand: "pip install -r requirements.txt"
     startCommand: "celery flower --app tasks --loglevel info"
+    autoDeploy: false
     envVars:
       - key: CELERY_BROKER_URL
         fromService:
@@ -40,5 +43,6 @@ services:
     name: celery-redis
     region: ohio
     plan: starter # we choose a plan with persistence to ensure tasks are not lost upon restart
+    autoDeploy: false
     maxmemoryPolicy: noeviction # recommended policy for queues
     ipAllowList: [] # only allow internal connections


### PR DESCRIPTION
By setting autoDeploy: false in the the render.yaml, we can ensure that subsequent merges to the main branch of this repository will not trigger deploys for any instances that have been created and deployed by the Deploy to Render button.

However, merging this PR will trigger a final forced deployment of any instances created and deployed by the Deploy to Render button.

See https://render.com/docs/deploy-to-render for more information.

Signed-off-by: zach wick <zach@render.com>