### PR TITLE
Give the celery worker an accurate name

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,6 +1,6 @@
 services:
   - type: worker
-    name: queue
+    name: celery-worker
     region: ohio
     env: python
     buildCommand: "pip install -r requirements.txt"


### PR DESCRIPTION
This PR renames the worker to reflect what it does.

The Redis service (line 42) serves as the queue.